### PR TITLE
Add Express REST API for UltraVox integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+PORT=3000
+TWILIO_ACCOUNT_SID=ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+TWILIO_AUTH_TOKEN=your_twilio_auth_token
+TWILIO_PHONE_NUMBER=+1234567890
+ULTRAVOX_API_KEY=your_ultravox_api_key
+N8N_RESULTS_URL=https://your-n8n-instance.example.com/webhook/post-call-results

--- a/README.md
+++ b/README.md
@@ -1,92 +1,64 @@
-# Ultravox Twilio Outbound Call Quickstart
+# Ultravox Twilio Outbound Call API
 
-This Node.js application demonstrates how to make outbound phone calls using Ultravox AI and Twilio. It sets up an AI-powered phone call where the AI agent (named Steve) will interact with the call recipient.
+This project exposes a simple Express server that integrates Ultravox AI with Twilio to place outbound phone calls. It is designed to work with an n8n workflow and provides two REST endpoints.
 
-## Prerequisites
+## Endpoints
 
-- Node.js (v18 or higher)
-- An Ultravox API key
-- A Twilio account with:
-  - Account SID
-  - Auth Token
-  - A phone number
+| Method | Endpoint          | Description                                               |
+| ------ | ----------------- | --------------------------------------------------------- |
+| POST   | `/trigger-call`   | Receive candidate data from n8n and initiate the call.    |
+| POST   | `/post-call-results` | Receive call results and forward them to the n8n workflow. |
 
 ## Setup
 
-1. Clone this repository
 1. Install dependencies:
-  ```bash
-  pnpm install
-  ```
+   ```bash
+   npm install
+   ```
+2. Copy `.env.example` to `.env` and fill in your credentials.
+3. Start the server:
+   ```bash
+   npm start
+   ```
 
-  or
-  ```bash
-  npm install
-  ```
+The server validates incoming payloads using **Joi** and reuses the existing Ultravox call logic.
 
-1. Configure your environment:
-   Open `index.js` and update the following constants with your credentials:
+## Environment Variables
 
-  ```javascript
-  // ------------------------------------------------------------
-  // Step 1:  Configure Twilio account and destination number
-  // ------------------------------------------------------------
-  const TWILIO_ACCOUNT_SID = 'your_twilio_account_sid_here';
-  const TWILIO_AUTH_TOKEN = 'your_twilio_auth_token_here';
-  const TWILIO_PHONE_NUMBER = 'your_twilio_phone_number_here';
-  const DESTINATION_PHONE_NUMBER = 'the_destination_phone_number_here';
+See `.env.example` for all required variables:
 
-  // ------------------------------------------------------------
-  // Step 2:  Configure Ultravox API key
-  //
-  // Optional: Modify the system prompt
-  // ------------------------------------------------------------
-  const ULTRAVOX_API_KEY = 'your_ultravox_api_key_here';
-  const SYSTEM_PROMPT = 'Your name is Steve and you are calling a person on the phone. Ask them their name and see how they are doing.';
-  ```
+- `TWILIO_ACCOUNT_SID` / `TWILIO_AUTH_TOKEN` – Twilio credentials
+- `TWILIO_PHONE_NUMBER` – Twilio phone number used to place calls
+- `ULTRAVOX_API_KEY` – Ultravox API key
+- `N8N_RESULTS_URL` – n8n webhook to receive post‑call results
 
-## Running the Application
+## Usage
 
-Start the application using either:
-  ```bash
-  pnpm start
-  ```
+Send a POST request to `/trigger-call` with a JSON body:
 
-  or 
+```json
+{
+  "candidateId": "string",
+  "candidateName": "string",
+  "candidatePhone": "string",
+  "candidateGender": "string",
+  "voice": "string"
+}
+```
 
-  ```bash
-  npm start
-  ```
+After the call completes, post the results to `/post-call-results`:
 
-The application will:
-1. Create an Ultravox call session
-1. Initiate a phone call through Twilio
-1. Connect the AI agent to the call
+```json
+{
+  "candidateId": "string",
+  "callStatus": "string",
+  "candidateResponse": "string",
+  "scheduledTime": "string",
+  "followUpRequired": true,
+  "callRecordingUrl": "string",
+  "transcript": "string"
+}
+```
 
-## Console Output
+The server will forward these results to the `N8N_RESULTS_URL`.
 
-When running successfully, you should see something like:
-  ```bash
-  🚀 Starting Outbound Ultravox Voice AI Phone Call...
-
-  ✅ Configuration validation passed!
-  📞 Creating Ultravox call...
-  ✅ Got Ultravox joinUrl: wss://prod-voice-pgaenaxiea-uc.a.run.app/calls/ULTRAVOX_CALL_ID/telephony
-  📱 Initiating Twilio call...
-  🎉 Twilio outbound phone call initiated successfully!
-  📋 Twilio Call SID: CA3b...
-  📞 Calling +12065551212 from +18005551212
-  ```
-
-## Troubleshooting
-
-If you encounter errors:
-1. Verify all API keys and credentials are correct
-1. Ensure the destination phone number is in a valid format (e.g., +1234567890)
-1. Check that your Twilio number is capable of making outbound calls
-
-## Project Structure
-
-- `index.js` - Main application file containing the call logic
-- `package.json` - Project dependencies and scripts
-- `README.md` - This documentation file

--- a/index.js
+++ b/index.js
@@ -1,154 +1,188 @@
+import express from 'express';
 import dotenv from 'dotenv';
-dotenv.config();
 import twilio from 'twilio';
 import https from 'https';
+import Joi from 'joi';
+import fetch from 'node-fetch';
 
+dotenv.config();
 
-// ------------------------------------------------------------
-// Step 1:  Configure Twilio account and destination number
-// ------------------------------------------------------------
-const TWILIO_ACCOUNT_SID = process.env.TWILIO_ACCOUNT_SID;
-const TWILIO_AUTH_TOKEN = process.env.TWILIO_AUTH_TOKEN;
-const TWILIO_PHONE_NUMBER = process.env.TWILIO_PHONE_NUMBER;
-const DESTINATION_PHONE_NUMBER = process.env.TO_PHONE_NUMBER;
+const {
+  PORT = 3000,
+  TWILIO_ACCOUNT_SID,
+  TWILIO_AUTH_TOKEN,
+  TWILIO_PHONE_NUMBER,
+  ULTRAVOX_API_KEY,
+  N8N_RESULTS_URL
+} = process.env;
 
-// ------------------------------------------------------------
-// Step 2:  Configure Ultravox API key
-//
-// Optional: Modify the system prompt
-// ------------------------------------------------------------
-const ULTRAVOX_API_KEY = process.env.ULTRAVOX_API_KEY;
 const SYSTEM_PROMPT = 'Your name is Steve and you are calling a person on the phone. Ask them their name and see how they are doing.';
 
-const ULTRAVOX_CALL_CONFIG = {
+const app = express();
+app.use(express.json());
+
+// ------------------------------------------------------------
+// Validation schemas
+// ------------------------------------------------------------
+const triggerSchema = Joi.object({
+  candidateId: Joi.string().required(),
+  candidateName: Joi.string().required(),
+  candidatePhone: Joi.string().required(),
+  candidateGender: Joi.string().required(),
+  voice: Joi.string().required()
+});
+
+const resultsSchema = Joi.object({
+  candidateId: Joi.string().required(),
+  callStatus: Joi.string().required(),
+  candidateResponse: Joi.string().required(),
+  scheduledTime: Joi.string().required(),
+  followUpRequired: Joi.boolean().required(),
+  callRecordingUrl: Joi.string().uri().required(),
+  transcript: Joi.string().required()
+});
+
+// ------------------------------------------------------------
+// Configuration validation
+// ------------------------------------------------------------
+function validateConfiguration() {
+  const required = [
+    { name: 'TWILIO_ACCOUNT_SID', value: TWILIO_ACCOUNT_SID, pattern: /^AC[a-zA-Z0-9]{32}$/ },
+    { name: 'TWILIO_AUTH_TOKEN', value: TWILIO_AUTH_TOKEN, pattern: /^[a-zA-Z0-9]{32}$/ },
+    { name: 'TWILIO_PHONE_NUMBER', value: TWILIO_PHONE_NUMBER, pattern: /^\+[1-9]\d{1,14}$/ },
+    { name: 'ULTRAVOX_API_KEY', value: ULTRAVOX_API_KEY, pattern: /^[a-zA-Z0-9]{8}\.[a-zA-Z0-9]{32}$/ },
+    { name: 'N8N_RESULTS_URL', value: N8N_RESULTS_URL, pattern: /^https?:\/\// }
+  ];
+
+  const errors = [];
+  for (const item of required) {
+    if (!item.value || item.value.includes('your_') || item.value.includes('_here')) {
+      errors.push(`${item.name} is not set or contains placeholder text`);
+    } else if (item.pattern && !item.pattern.test(item.value)) {
+      errors.push(`${item.name} format appears invalid`);
+    }
+  }
+
+  if (errors.length) {
+    console.error('Configuration Error(s):');
+    errors.forEach(e => console.error(` - ${e}`));
+    process.exit(1);
+  }
+  console.log('✅ Configuration validation passed!');
+}
+
+// ------------------------------------------------------------
+// Ultravox call creation
+// ------------------------------------------------------------
+function createUltravoxCall(voice) {
+  const callConfig = {
     systemPrompt: SYSTEM_PROMPT,
     model: 'fixie-ai/ultravox',
-    voice: 'Mark',
+    voice,
     temperature: 0.3,
-    firstSpeakerSettings: { user: {} },     // For outgoing calls, the user will answer the call (i.e. speak first)
-    medium: { twilio: {} }                  // Use twilio medium
-};
+    firstSpeakerSettings: { user: {} },
+    medium: { twilio: {} }
+  };
 
-// Validates all required config vars are set
-function validateConfiguration() {
-    const requiredConfig = [
-        { name: 'TWILIO_ACCOUNT_SID', value: TWILIO_ACCOUNT_SID, pattern: /^AC[a-zA-Z0-9]{32}$/ },
-        { name: 'TWILIO_AUTH_TOKEN', value: TWILIO_AUTH_TOKEN, pattern: /^[a-zA-Z0-9]{32}$/ },
-        { name: 'TWILIO_PHONE_NUMBER', value: TWILIO_PHONE_NUMBER, pattern: /^\+[1-9]\d{1,14}$/ },
-        { name: 'DESTINATION_PHONE_NUMBER', value: DESTINATION_PHONE_NUMBER, pattern: /^\+[1-9]\d{1,14}$/ },
-        { name: 'ULTRAVOX_API_KEY', value: ULTRAVOX_API_KEY, pattern: /^[a-zA-Z0-9]{8}\.[a-zA-Z0-9]{32}$/ }
-    ];
-
-    const errors = [];
-
-    for (const config of requiredConfig) {
-        if (!config.value || config.value.includes('your_') || config.value.includes('_here')) {
-            errors.push(`❌ ${config.name} is not set or still contains placeholder text`);
-        } else if (config.pattern && !config.pattern.test(config.value)) {
-            errors.push(`❌ ${config.name} format appears invalid`);
-        }
+  const request = https.request('https://api.ultravox.ai/api/calls', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-API-Key': ULTRAVOX_API_KEY
     }
+  });
 
-    if (errors.length > 0) {
-        console.error('🚨 Configuration Error(s):');
-        errors.forEach(error => console.error(`   ${error}`));
-        console.error('\n💡 Please update the configuration variables at the top of this file:');
-        console.error('   • TWILIO_ACCOUNT_SID should start with "AC" and be 34 characters');
-        console.error('   • TWILIO_AUTH_TOKEN should be 32 characters');
-        console.error('   • Phone numbers should be in E.164 format (e.g., +1234567890)');
-        console.error('   • ULTRAVOX_API_KEY should be 8 chars + period + 32 chars (e.g., Zk9Ht7Lm.wX7pN9fM3kLj6tRq2bGhA8yE5cZvD4sT)');
-        console.error('\n📦 If you get module import errors, install dependencies with:');
-        console.error('   npm install twilio');
-        process.exit(1);
-    }
-
-    console.log('✅ Configuration validation passed!');
-}
-
-// Creates the Ultravox call using the above config
-async function createUltravoxCall() {
-    const ULTRAVOX_API_URL = 'https://api.ultravox.ai/api/calls';
-    const request = https.request(ULTRAVOX_API_URL, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            'X-API-Key': ULTRAVOX_API_KEY
+  return new Promise((resolve, reject) => {
+    let data = '';
+    request.on('response', response => {
+      response.on('data', chunk => data += chunk);
+      response.on('end', () => {
+        try {
+          const parsed = JSON.parse(data);
+          if (response.statusCode >= 200 && response.statusCode < 300) {
+            resolve(parsed);
+          } else {
+            reject(new Error(`Ultravox API error (${response.statusCode}): ${data}`));
+          }
+        } catch (err) {
+          reject(new Error(`Failed to parse Ultravox response: ${data}`));
         }
+      });
     });
+    request.on('error', err => reject(err));
+    request.write(JSON.stringify(callConfig));
+    request.end();
+  });
+}
 
-    return new Promise((resolve, reject) => {
-        let data = '';
-        request.on('response', (response) => {
-            response.on('data', chunk => data += chunk);
-            response.on('end', () => {
-                try {
-                    const parsedData = JSON.parse(data);
-                    if (response.statusCode >= 200 && response.statusCode < 300) {
-                        resolve(parsedData);
-                    } else {
-                        reject(new Error(`Ultravox API error (${response.statusCode}): ${data}`));
-                    }
-                } catch (parseError) {
-                    reject(new Error(`Failed to parse Ultravox response: ${data}`));
-                }
-            });
-        });
-        request.on('error', (error) => {
-            reject(new Error(`Network error calling Ultravox: ${error.message}`));
-        });
-        request.write(JSON.stringify(ULTRAVOX_CALL_CONFIG));
-        request.end();
+async function triggerUltraVoxCall(data) {
+  console.log('📞 Creating Ultravox call...');
+  const uv = await createUltravoxCall(data.voice);
+  console.log('✅ Got Ultravox joinUrl:', uv.joinUrl);
+
+  console.log('📱 Initiating Twilio call...');
+  const client = twilio(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN);
+  const call = await client.calls.create({
+    twiml: `<Response><Connect><Stream url="${uv.joinUrl}"/></Connect></Response>`,
+    to: data.candidatePhone,
+    from: TWILIO_PHONE_NUMBER
+  });
+
+  console.log('🎉 Twilio outbound phone call initiated!');
+  console.log(`📋 Twilio Call SID: ${call.sid}`);
+  return { joinUrl: uv.joinUrl, callSid: call.sid };
+}
+
+async function postResultsToN8n(results) {
+  if (!N8N_RESULTS_URL) {
+    console.warn('N8N_RESULTS_URL not configured; skipping posting results');
+    return;
+  }
+  try {
+    const res = await fetch(N8N_RESULTS_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(results)
     });
-}
-
-// Starts the program and makes the call
-async function main() {
-    console.log('🚀 Starting Outbound Ultravox Voice AI Phone Call...\n');
-    validateConfiguration();
-    
-    try {
-        console.log('📞 Creating Ultravox call...');
-        const ultravoxResponse = await createUltravoxCall();
-        
-        if (!ultravoxResponse.joinUrl) {
-            throw new Error('No joinUrl received from Ultravox API');
-        }
-        
-        console.log('✅ Got Ultravox joinUrl:', ultravoxResponse.joinUrl);
-
-        console.log('📱 Initiating Twilio call...');
-        const client = twilio(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN);
-        
-        const call = await client.calls.create({
-            twiml: `<Response><Connect><Stream url="${ultravoxResponse.joinUrl}"/></Connect></Response>`,
-            to: DESTINATION_PHONE_NUMBER,
-            from: TWILIO_PHONE_NUMBER
-        });
-
-        console.log('🎉 Twilio outbound phone call initiated successfully!');
-        console.log(`📋 Twilio Call SID: ${call.sid}`);
-        console.log(`📞 Calling ${DESTINATION_PHONE_NUMBER} from ${TWILIO_PHONE_NUMBER}`);
-        
-    } catch (error) {
-        console.error('💥 Error occurred:');
-        
-        if (error.message.includes('Authentication')) {
-            console.error('   🔐 Authentication failed - check your Twilio credentials');
-        } else if (error.message.includes('phone number')) {
-            console.error('   📞 Phone number issue - verify your phone numbers are correct');
-        } else if (error.message.includes('Ultravox')) {
-            console.error('   🤖 Ultravox API issue - check your API key and try again');
-        } else {
-            console.error(`   ${error.message}`);
-        }
-        
-        console.error('\n🔍 Troubleshooting tips:');
-        console.error('   • Double-check all configuration values');
-        console.error('   • Ensure phone numbers are in E.164 format (+1234567890)');
-        console.error('   • Verify your Twilio account has sufficient balance');
-        console.error('   • Check that your Ultravox API key is valid');
-        console.error('   • If you get import errors, run: npm install twilio');
+    if (!res.ok) {
+      console.error(`Failed posting results to n8n: ${res.status} ${res.statusText}`);
+    } else {
+      console.log('✅ Posted call results to n8n');
     }
+  } catch (err) {
+    console.error('Error posting results to n8n:', err.message);
+  }
 }
 
-main();
+// ------------------------------------------------------------
+// Express Endpoints
+// ------------------------------------------------------------
+app.post('/trigger-call', async (req, res) => {
+  const { error } = triggerSchema.validate(req.body);
+  if (error) {
+    return res.status(400).json({ error: error.details[0].message });
+  }
+
+  try {
+    const callInfo = await triggerUltraVoxCall(req.body);
+    res.json({ status: 'initiated', data: callInfo });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/post-call-results', async (req, res) => {
+  const { error } = resultsSchema.validate(req.body);
+  if (error) {
+    return res.status(400).json({ error: error.details[0].message });
+  }
+
+  await postResultsToN8n(req.body);
+  res.json({ status: 'received' });
+});
+
+app.listen(PORT, () => {
+  validateConfiguration();
+  console.log(`🚀 Server listening on port ${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   },
   "dependencies": {
     "dotenv": "^17.0.1",
+    "express": "^4.18.2",
+    "joi": "^17.9.2",
+    "node-fetch": "^3.3.1",
     "twilio": "^5.4.0"
   }
 }


### PR DESCRIPTION
## Summary
- implement Express server with `/trigger-call` and `/post-call-results`
- forward call results to n8n
- provide example `.env` and update docs
- add dependencies: express, joi and node-fetch

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_686a3395ac848320bbd0560227102384